### PR TITLE
Support only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,19 @@ class SomeController < ApplicationController
 end
 ```
 
+And let's say you want to use database template resolving in all your controllers, but
+want to use panoramic only for certain paths (prefixed with X) you can use
+
+```ruby
+class ApplicationController < ActionController::Base
+  prepend_view_path TemplateStorage.resolver(:only => 'use_this_prefix_only')
+end
+```
+
+This helps reducing the number of database requests, if Rails for example tries to look
+for layouts per controller.
+
+
 ## Documentation
 Need more help? Check out ```spec/dummy/```, you'll find a *dummy* rails app I used to make tests ;-)
 

--- a/lib/panoramic/orm/active_record.rb
+++ b/lib/panoramic/orm/active_record.rb
@@ -20,8 +20,8 @@ module Panoramic
           self.where(conditions)
         end
 
-        def resolver
-          Panoramic::Resolver.using self
+        def resolver(options={})
+          Panoramic::Resolver.using self, options
         end
       end
     end

--- a/lib/panoramic/resolver.rb
+++ b/lib/panoramic/resolver.rb
@@ -5,6 +5,8 @@ module Panoramic
 
     # this method is mandatory to implement a Resolver
     def find_templates(name, prefix, partial, details)
+      return [] if @@resolver_options[:only] && !@@resolver_options[:only].include?(prefix)
+
       conditions = {
         :path    => build_path(name, prefix),
         :locale  => normalize_array(details[:locale]).first,
@@ -19,8 +21,9 @@ module Panoramic
     end
 
     # Instantiate Resolver by passing a model (decoupled from ORMs)
-    def self.using(model)
+    def self.using(model, options={})
       @@model = model
+      @@resolver_options = options
       self.instance
     end
 

--- a/spec/resolver_spec.rb
+++ b/spec/resolver_spec.rb
@@ -4,9 +4,20 @@ describe Panoramic::Resolver do
   let(:resolver) { Panoramic::Resolver.using(DatabaseTemplate) }
 
   context ".find_templates" do
-    it "lookups templates for given params" do
+    it "should lookup templates for given params" do
       template = FactoryGirl.create(:database_template, :path => 'foo/example')
       details = { :formats => [:html], :locale => [:en], :handlers => [:erb] }
+      resolver.find_templates('example', 'foo', false, details).first.should_not be_nil
+    end
+
+    it "should lookup templates for given params and prefixes" do
+      resolver = Panoramic::Resolver.using(DatabaseTemplate, :only => 'foo')
+      details = { :formats => [:html], :locale => [:en], :handlers => [:erb] }
+
+      template = FactoryGirl.create(:database_template, :path => 'bar/example')
+      resolver.find_templates('example', 'bar', false, details).first.should be_nil
+
+      template = FactoryGirl.create(:database_template, :path => 'foo/example')
       resolver.find_templates('example', 'foo', false, details).first.should_not be_nil
     end
   end


### PR DESCRIPTION
If you add

``` ruby
append_view_path TemplateStorage.resolver
```

to your application controller, in order to allow database lookup for all controllers, then Rails is sending requests to the database even for layout template (which by purpose don't exist). In order to keep the number of database requests small, I introduced an optional parameter, which can be used like this

``` ruby
class ApplicationController < ActionController::Base
  append_view_path TemplateStorage.resolver(:only => 'use_this_prefix_only')
end
```

This make sure all template requests have to have the prefix 'use_this_prefix_only' . Otherwise the database lookup doesn't take place.
