### PR TITLE
fix(Resolver): allow additional details to be passed to Resolver.

### DIFF
--- a/lib/panoramic/resolver.rb
+++ b/lib/panoramic/resolver.rb
@@ -13,7 +13,7 @@ module Panoramic
         :format  => normalize_array(details[:formats]),
         :handler => normalize_array(details[:handlers]),
         :partial => partial || false
-      }
+      }.merge(details[:additional_criteria].presence || {})
 
       @@model.find_model_templates(conditions).map do |record|
         initialize_template(record)

--- a/panoramic.gemspec
+++ b/panoramic.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = "panoramic"
-  s.version     ='0.0.6'
+  s.version     ='0.0.7'
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Andrea Pavoni"]
   s.email       = ["andrea.pavoni@gmail.com"]


### PR DESCRIPTION
This allows for additional query parameters to be passed to Panoramic::Resolver, which is necessary in a multi tenant environment.

For instance, our system allows for each tenant to have their own version of a Panoramic template, but currently this scenario can occur: 

User A comes to Tenant/Environment 1, template with name "custom_css"  and tenant_id 1 is cached.
User A switches to Tenant/Environment 2, template with name "custom_css" and tenant_id 1 is loaded from cache.

I have simply added plumbing so that you may pass an additional hash to the render method, which will affect the query generated by the find_model_templates method.