### PR TITLE
[bug] assure format is a symbol

### DIFF
--- a/lib/panoramic/resolver.rb
+++ b/lib/panoramic/resolver.rb
@@ -38,7 +38,7 @@ module Panoramic
       handler = ActionView::Template.registered_template_handler(record.handler)
 
       details = {
-        :format => Mime[record.format],
+        :format => Mime[record.format].to_sym,
         :updated_at => record.updated_at,
         :virtual_path => virtual_path(record.path, record.partial)
       }


### PR DESCRIPTION
I ran in to an issue when using Panoramic with Rails6 and Ruby 2.7.0. The error is caused by `Mime[record.format]` returning an object instead of `to_sym`. I have not investigated what version permutation introduced the change.

I've created an example project to reproduce the error: https://github.com/vandux/panoramic_error

<img width="1229" alt="Screen Shot 2019-12-28 at 8 51 00 AM" src="https://user-images.githubusercontent.com/368696/71544944-32d3ff00-2953-11ea-9699-b895039fb2c9.png">