### PR TITLE
add path for resolver flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ for layouts per controller.
 class MyEmail < ActionMailer::Base
   prepend_view_path TemplateStorage.resolver
 ```
+Using prepend_view_path/append_view_path you are stuck to the current context (e.g. the method calling "mail").
+If you want to dynamically change the path depending on a certain variable, call the prepend_view_path/append_view_path inside the method's context with an additional path variable.
+This could be useful, if you want to use only one method for sending different templates depending on the template.path .
+
+```ruby
+class MyEmail < ActionMailer::Base
+
+  def method_that_sets_resolver_path
+    prepend_view_path TemplateStorage.resolver(:path => model.path)
+  end
+```
 
 ## Documentation
 Need more help? Check out ```spec/dummy/```, you'll find a *dummy* rails app I used to make tests ;-)

--- a/lib/panoramic/resolver.rb
+++ b/lib/panoramic/resolver.rb
@@ -7,7 +7,8 @@ module Panoramic
     def find_templates(name, prefix, partial, details, key=nil, locals=[])
       return [] if @@resolver_options[:only] && !@@resolver_options[:only].include?(prefix)
 
-      path = build_path(name, prefix)
+      path = @@resolver_options[:path].present? ? @@resolver_options[:path] : build_path(name, prefix)
+
       conditions = {
         :path    => path,
         :locale  => [normalize_array(details[:locale]).first, nil],
@@ -16,7 +17,7 @@ module Panoramic
         :partial => partial || false
       }.merge(details[:additional_criteria].presence || {})
 
-      @@model.find_model_templates(conditions).map do |record|
+      @@model.find_model_templates(conditions)&.map do |record|
         Rails.logger.debug "Rendering template from database: #{path} (#{record.format})"
         initialize_template(record)
       end


### PR DESCRIPTION
In our use case we send different templates with only one method, but the append/prepend_view_path is constained by the current context.
In the given example with ActionMailer:

```ruby
class MyEmail < ActionMailer::Base
    prepend_view_path TemplateStorage.resolver

  def send
    mail from: xxx, to: xxx, subject: xxx
  end
```
The resolver will get as path "my_email/send".
But we want to dynamically use templates without always having to write new methods. E.g.

```ruby
class MyEmail < ActionMailer::Base

  def send
    @template = MyTemplate.find(params[:template_id])
    prepend_view_path MyTemplate.resolver(:path => @template.path)

    mail from: xxx, to: xxx, subject: xxx
  end
```

so given path to the resolver sets the context to search for.

The main functionality will stay the same.